### PR TITLE
create docker-compose-aci to create image without networking requirement

### DIFF
--- a/docker-compose-aci.yml
+++ b/docker-compose-aci.yml
@@ -1,0 +1,15 @@
+services:
+  daikon_chem_vault_api:
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - "10001:10001"
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      LOG_LEVEL: ${LOG_LEVEL}
+      LOG_JSON: ${LOG_JSON}
+    # depends_on:
+    #   - daikon_chem_vault_db


### PR DESCRIPTION
Added:
- Create docker-compose-aci.yml which removes network requirement from the docker compose.