### PR TITLE
Add Codex docker-compose stack for local development

### DIFF
--- a/.env.codex.example
+++ b/.env.codex.example
@@ -1,0 +1,8 @@
+# Codex-friendly defaults for local development
+POSTGRES_USER=chemvault
+POSTGRES_PASSWORD=chemvault
+POSTGRES_DB=chemvault
+LOG_LEVEL=INFO
+LOG_JSON=false
+# Async SQLAlchemy connection string pointing at the bundled DB service
+DATABASE_URL=postgresql+asyncpg://chemvault:chemvault@daikon_chem_vault_db:5432/chemvault

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # daikon-chemvault
+
+## Running in Codex
+
+For local development inside the Codex environment, use the dedicated compose stack that bundles the API and PostgreSQL database.
+
+1. Copy the sample environment and adjust values if needed:
+   ```bash
+   cp .env.codex.example .env.codex
+   ```
+2. Start the stack:
+   ```bash
+   docker-compose -f docker-compose.codex.yml up --build
+   ```
+
+The API is exposed on port `10001`, and the database is reachable at `daikon_chem_vault_db:5432` using the credentials in `.env.codex`.
+
+The existing compose files remain unchanged for production usage.

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -1,0 +1,38 @@
+version: "3.9"
+
+services:
+  daikon_chem_vault_db:
+    image: informaticsmatters/rdkit-cartridge-debian:Release_2024_03_3
+    restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-chemvault}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-chemvault}
+      POSTGRES_DB: ${POSTGRES_DB:-chemvault}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - codex-net
+
+  daikon_chem_vault_api:
+    build: .
+    depends_on:
+      - daikon_chem_vault_db
+    volumes:
+      - .:/app
+    ports:
+      - "10001:10001"
+    env_file:
+      - .env.codex
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://${POSTGRES_USER:-chemvault}:${POSTGRES_PASSWORD:-chemvault}@daikon_chem_vault_db:5432/${POSTGRES_DB:-chemvault}}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      LOG_JSON: ${LOG_JSON:-false}
+    networks:
+      - codex-net
+
+networks:
+  codex-net:
+    driver: bridge
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add a Codex-specific docker-compose stack that includes the API and database with internal networking defaults
- provide a sample Codex environment file with safe defaults for the bundled services
- document Codex usage while leaving the production compose files unchanged

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934e9448f6c832ca29d10dd8a0ef63e)